### PR TITLE
delete blockpercept

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -112,6 +112,12 @@ namespace NineChronicles.Snapshot
                     File.Delete(snapshotPath);
                 }
 
+                var blockPerceptPath = Path.Combine(storePath, "blockpercept");
+                if (Directory.Exists(blockPerceptPath))
+                {
+                    Directory.Delete(blockPerceptPath, true);
+                }
+
                 ZipFile.CreateFromDirectory(storePath, snapshotPath);
 
                 if (snapshotTipDigest is null)


### PR DESCRIPTION
This PR deletes the `blockpercept` directory recursively before creating a zipfile of the chain data.
Reference: https://github.com/planetarium/libplanet/blob/95a8409bf11017d742be14ff19e49b913ceaeb42/Libplanet.RocksDBStore/RocksDBStore.cs#L25