### PR TITLE
support data partitioning

### DIFF
--- a/NineChronicles.Snapshot.csproj
+++ b/NineChronicles.Snapshot.csproj
@@ -8,8 +8,8 @@
 
   <ItemGroup>
     <PackageReference Include="Cocona.Lite" Version="1.3.0" />
-    <PackageReference Include="Libplanet" Version="0.11.0-dev.20210217041916" />
-    <PackageReference Include="Libplanet.RocksDBStore" Version="0.11.0-dev.20210217041916" />
+    <PackageReference Include="Libplanet" Version="0.11.0-dev.20210305044021" />
+    <PackageReference Include="Libplanet.RocksDBStore" Version="0.11.0-dev.20210305044021" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
   </ItemGroup>
 

--- a/Program.cs
+++ b/Program.cs
@@ -31,7 +31,6 @@ namespace NineChronicles.Snapshot
         [Command]
         public void Snapshot(
             string apv,
-            string workingDirectory,
             [Option('o')]
             string outputDirectory = null,
             string storePath = null,
@@ -57,17 +56,13 @@ namespace NineChronicles.Snapshot
                 throw new CommandExitedException("Invalid store path. Please check --store-path is valid.", -1);
             }
 
-            if (!Directory.Exists(workingDirectory))
+            string workingDirectory = Path.Combine(Path.GetTempPath(), "snapshot");
+            if (Directory.Exists(workingDirectory))
             {
-                throw new CommandExitedException("Invalid working directory path. Please check --working-directory is valid.", -1);
-
-            }
-            else
-            {
-                CleanDirectory(workingDirectory);
-                CloneDirectory(storePath, workingDirectory);
+                Directory.Delete(workingDirectory, true);
             }
 
+            CloneDirectory(storePath, workingDirectory);
             var statesPath = Path.Combine(workingDirectory, "states");
             var stateHashesPath = Path.Combine(workingDirectory, "state_hashes");
 
@@ -175,6 +170,7 @@ namespace NineChronicles.Snapshot
                 }
 
                 File.WriteAllText(metadataPath, jsonString);
+                Directory.Delete(workingDirectory, true);
             }
             else
             {
@@ -290,19 +286,6 @@ namespace NineChronicles.Snapshot
             foreach (var file in Directory.GetFiles(source))
             {
                 File.Copy(file, Path.Combine(dest, Path.GetFileName(file)));
-            }
-        }
-
-        private static void CleanDirectory(string path)
-        {
-            System.IO.DirectoryInfo di = new DirectoryInfo(path);
-            foreach (FileInfo file in di.GetFiles())
-            {
-                file.Delete(); 
-            }
-            foreach (DirectoryInfo dir in di.GetDirectories())
-            {
-                dir.Delete(true); 
             }
         }
 

--- a/Program.cs
+++ b/Program.cs
@@ -47,9 +47,9 @@ namespace NineChronicles.Snapshot
             );
 
             Directory.CreateDirectory(outputDirectory);
-            Directory.CreateDirectory(outputDirectory + "/partition");
-            Directory.CreateDirectory(outputDirectory + "/state");
-            Directory.CreateDirectory(outputDirectory + "/metadata");
+            Directory.CreateDirectory(Path.Combine(outputDirectory, "partition"));
+            Directory.CreateDirectory(Path.Combine(outputDirectory, "state"));
+            Directory.CreateDirectory(Path.Combine(outputDirectory, "metadata"));
 
             outputDirectory = string.IsNullOrEmpty(outputDirectory)
                 ? Environment.CurrentDirectory
@@ -81,7 +81,7 @@ namespace NineChronicles.Snapshot
             var canonicalChainId = _store.GetCanonicalChainId();
             if (!(canonicalChainId is Guid chainId))
             {
-                throw new CommandExitedException("Canonical chain doesn't exists.", -1);
+                throw new CommandExitedException("Canonical chain doesn't exist.", -1);
             }
 
             var genesisHash = _store.IterateIndexes(chainId, 0, 1).First();
@@ -137,9 +137,9 @@ namespace NineChronicles.Snapshot
             var stateBaseFilename = $"state_latest";
 
             var partitionSnapshotFilename = $"{partitionBaseFilename}.zip";
-            var partitionSnapshotPath = Path.Combine(outputDirectory + "/partition", partitionSnapshotFilename);
+            var partitionSnapshotPath = Path.Combine(outputDirectory, "partition", partitionSnapshotFilename);
             var stateSnapshotFilename = $"{stateBaseFilename}.zip";
-            var stateSnapshotPath = Path.Combine(outputDirectory + "/state", stateSnapshotFilename);
+            var stateSnapshotPath = Path.Combine(outputDirectory, "state", stateSnapshotFilename);
             string partitionDirectory = Path.Combine(Path.GetTempPath(), "snapshot");
             string stateDirectory = Path.Combine(Path.GetTempPath(), "state");
             CleanStore(
@@ -178,7 +178,7 @@ namespace NineChronicles.Snapshot
             ZipFile.CreateFromDirectory(stateDirectory, stateSnapshotPath);
             if (snapshotTipDigest is null)
             {
-                throw new CommandExitedException("Tip does not exists.", -1);
+                throw new CommandExitedException("Tip does not exist.", -1);
             }
 
             string stringfyMetadata = GetMetadata(
@@ -253,73 +253,42 @@ namespace NineChronicles.Snapshot
                 File.Delete(stateSnapshotPath);
             }
 
-            var blockPerceptPath = Path.Combine(storePath, "blockpercept");
-            if (Directory.Exists(blockPerceptPath))
+            var cleanDirectories = new[]
             {
-                Directory.Delete(blockPerceptPath, true);
-            }
+                Path.Combine(storePath, "blockpercept"),
+                Path.Combine(storePath, "stagedtx"),
+                partitionDirectory,
+                stateDirectory
+            };
 
-            var stagedTxPath = Path.Combine(storePath, "stagedtx");
-            if (Directory.Exists(stagedTxPath))
+            foreach (var path in cleanDirectories)
             {
-                Directory.Delete(stagedTxPath, true);
-            }
-
-            if (Directory.Exists(partitionDirectory))
-            {
-                Directory.Delete(partitionDirectory, true);
-            }
-
-            if (Directory.Exists(stateDirectory))
-            {
-                Directory.Delete(stateDirectory, true);
+                if (Directory.Exists(path))
+                {
+                    Directory.Delete(path, true);
+                }
             }
         }
 
         private void CleanPartitionStore(string partitionDirectory)
         {
-            var statePath = Path.Combine(partitionDirectory, "state");
-            if (Directory.Exists(statePath))
+            var cleanDirectories = new[]
             {
-            Directory.Delete(statePath, true);
-            }
+                Path.Combine(partitionDirectory, "state"),
+                Path.Combine(partitionDirectory, "state_hashes"),
+                Path.Combine(partitionDirectory, "stateref"),
+                Path.Combine(partitionDirectory, "states"),
+                Path.Combine(partitionDirectory, "chain"),
+                Path.Combine(partitionDirectory, "block", "blockindex"),
+                Path.Combine(partitionDirectory, "tx", "txindex"),
+            };
 
-            var stateHashesPath = Path.Combine(partitionDirectory, "state_hashes");
-            if (Directory.Exists(stateHashesPath))
+            foreach (var path in cleanDirectories)
             {
-            Directory.Delete(stateHashesPath, true);
-            }
-
-            var stateRefPath = Path.Combine(partitionDirectory, "stateref");
-            if (Directory.Exists(stateRefPath))
-            {
-            Directory.Delete(stateRefPath, true);
-            }
-
-            var statesPath = Path.Combine(partitionDirectory, "states");
-            if (Directory.Exists(statesPath))
-            {
-            Directory.Delete(statesPath, true);
-            }
-
-            var chainPath = Path.Combine(partitionDirectory, "chain");
-            if (Directory.Exists(chainPath))
-            {
-            Directory.Delete(chainPath, true);
-            }
-
-            var blockPath = Path.Combine(partitionDirectory, "block");
-            var blockIndexPath = Path.Combine(blockPath, "blockindex");
-            if (Directory.Exists(blockIndexPath))
-            {
-            Directory.Delete(blockIndexPath, true);
-            }
-
-            var txPath = Path.Combine(partitionDirectory, "tx");
-            var txIndexPath = Path.Combine(txPath, "txindex");
-            if (Directory.Exists(txIndexPath))
-            {
-            Directory.Delete(txIndexPath, true);
+                if (Directory.Exists(path))
+                {
+                    Directory.Delete(path, true);
+                }
             }
         }
 

--- a/Program.cs
+++ b/Program.cs
@@ -128,7 +128,7 @@ namespace NineChronicles.Snapshot
 
                 var genesisHashHex = ByteUtil.Hex(genesisHash.ToByteArray());
                 var snapshotTipHashHex = ByteUtil.Hex(snapshotTipHash.ToByteArray());
-                var snapshotFilename = $"{genesisHashHex}-snapshot-{latestBlockEpoch}-{latestTxEpoch}.zip";
+                var snapshotFilename = $"snapshot-{latestBlockEpoch}-{latestTxEpoch}.zip";
                 var snapshotPath = Path.Combine(outputDirectory, snapshotFilename);
                 if (File.Exists(snapshotPath))
                 {
@@ -161,11 +161,13 @@ namespace NineChronicles.Snapshot
                 var snapshotTipHeader = snapshotTipDigest.Value.Header;
                 JObject jsonObject = JObject.FromObject(snapshotTipHeader);
                 jsonObject.Add("APV", apv);
+                jsonObject.Add("PreviousBlockEpoch", metadataBlockEpoch);
+                jsonObject.Add("PreviousTxEpoch", metadataTxEpoch);
                 jsonObject.Add("BlockEpoch", latestBlockEpoch);
                 jsonObject.Add("TxEpoch", latestTxEpoch);
                 var jsonString = JsonConvert.SerializeObject(jsonObject);
 
-                var metadataFilename = $"{genesisHashHex}-snapshot-{latestBlockEpoch}-{latestTxEpoch}.json";
+                var metadataFilename = $"snapshot-{latestBlockEpoch}-{latestTxEpoch}.json";
                 var metadataPath = Path.Combine(outputDirectory, metadataFilename);
                 if (File.Exists(metadataPath))
                 {

--- a/Program.cs
+++ b/Program.cs
@@ -56,17 +56,10 @@ namespace NineChronicles.Snapshot
                 throw new CommandExitedException("Invalid store path. Please check --store-path is valid.", -1);
             }
 
-            string workingDirectory = Path.Combine(Path.GetTempPath(), "snapshot");
-            if (Directory.Exists(workingDirectory))
-            {
-                Directory.Delete(workingDirectory, true);
-            }
+            var statesPath = Path.Combine(storePath, "states");
+            var stateHashesPath = Path.Combine(storePath, "state_hashes");
 
-            CloneDirectory(storePath, workingDirectory);
-            var statesPath = Path.Combine(workingDirectory, "states");
-            var stateHashesPath = Path.Combine(workingDirectory, "state_hashes");
-
-            _store = new RocksDBStore(workingDirectory);
+            _store = new RocksDBStore(storePath);
             IKeyValueStore stateKeyValueStore = new RocksDBKeyValueStore(statesPath);
             IKeyValueStore stateHashKeyValueStore = new RocksDBKeyValueStore(stateHashesPath);
             _stateStore = new TrieStateStore(stateKeyValueStore, stateHashKeyValueStore);
@@ -131,17 +124,25 @@ namespace NineChronicles.Snapshot
                     File.Delete(snapshotPath);
                 }
 
-                var blockPerceptPath = Path.Combine(workingDirectory, "blockpercept");
+                var blockPerceptPath = Path.Combine(storePath, "blockpercept");
                 if (Directory.Exists(blockPerceptPath))
                 {
                     Directory.Delete(blockPerceptPath, true);
                 }
 
-                var stagedTxPath = Path.Combine(workingDirectory, "stagedtx");
+                var stagedTxPath = Path.Combine(storePath, "stagedtx");
                 if (Directory.Exists(stagedTxPath))
                 {
                     Directory.Delete(stagedTxPath, true);
                 }
+
+                string workingDirectory = Path.Combine(Path.GetTempPath(), "snapshot");
+                if (Directory.Exists(workingDirectory))
+                {
+                    Directory.Delete(workingDirectory, true);
+                }
+
+                CloneDirectory(storePath, workingDirectory);
 
                 var blockPath = Path.Combine(workingDirectory, "block");
                 var txPath = Path.Combine(workingDirectory, "tx");

--- a/Program.cs
+++ b/Program.cs
@@ -153,8 +153,24 @@ namespace NineChronicles.Snapshot
 
             var blockPath = Path.Combine(partitionDirectory, "block");
             var txPath = Path.Combine(partitionDirectory, "tx");
-            CleanEpoch(blockPath, currentMetadataBlockEpoch);
-            CleanEpoch(txPath, currentMetadataTxEpoch);
+            if (currentMetadataBlockEpoch == latestBlockEpoch)
+            {
+                CleanEpoch(blockPath, previousMetadataBlockEpoch);
+            }
+            else
+            {
+                CleanEpoch(blockPath, currentMetadataBlockEpoch);
+            }
+
+            if (currentMetadataTxEpoch == latestTxEpoch)
+            {
+                CleanEpoch(txPath, previousMetadataTxEpoch);
+            }
+            else
+            {
+                CleanEpoch(txPath, currentMetadataTxEpoch);
+            }
+
             CleanPartitionStore(partitionDirectory);
             CleanStateStore(stateDirectory);
 
@@ -415,7 +431,7 @@ namespace NineChronicles.Snapshot
             }
         }
 
-        private void CleanEpoch(string path, int currentMetadataEpoch)
+        private void CleanEpoch(string path, int epochLimit)
         {
             string[] directories = Directory.GetDirectories(
                 path,
@@ -427,7 +443,7 @@ namespace NineChronicles.Snapshot
                 {
                     string dirName = new DirectoryInfo(dir).Name;
                     int epoch = Int32.Parse(dirName.Substring(5));
-                    if (epoch <= currentMetadataEpoch)
+                    if (epoch + 1 < epochLimit)
                     {
                         Directory.Delete(dir, true);
                     }

--- a/Program.cs
+++ b/Program.cs
@@ -160,17 +160,23 @@ namespace NineChronicles.Snapshot
                 var snapshotTipHeader = snapshotTipDigest.Value.Header;
                 JObject jsonObject = JObject.FromObject(snapshotTipHeader);
                 jsonObject.Add("APV", apv);
-                jsonObject = AddPreviousEpoch(
+                jsonObject = AddPreviousBlockEpoch(
                     jsonObject,
                     currentMetadataBlockEpoch,
-                    latestBlockEpoch,
-                    previousMetadataBlockEpoch,
-                    "PreviousBlockEpoch");
-                jsonObject = AddPreviousEpoch(
-                    jsonObject,
                     currentMetadataTxEpoch,
-                    latestTxEpoch,
+                    previousMetadataBlockEpoch,
                     previousMetadataTxEpoch,
+                    latestBlockEpoch,
+                    latestTxEpoch,
+                    "PreviousBlockEpoch");
+                jsonObject = AddPreviousTxEpoch(
+                    jsonObject,
+                    currentMetadataBlockEpoch,
+                    currentMetadataTxEpoch,
+                    previousMetadataBlockEpoch,
+                    previousMetadataTxEpoch,
+                    latestBlockEpoch,
+                    latestTxEpoch,
                     "PreviousTxEpoch");
                 jsonObject.Add("BlockEpoch", latestBlockEpoch);
                 jsonObject.Add("TxEpoch", latestTxEpoch);
@@ -326,20 +332,60 @@ namespace NineChronicles.Snapshot
                 throw new FormatException("Epoch value is not numeric.");
             }
         }
-        private static JObject AddPreviousEpoch(
+
+        private static JObject AddPreviousTxEpoch(
             JObject jsonObject,
-            int currentMetadataEpoch,
-            int latestEpoch,
-            int previousMetadataEpoch,
-            string epochName)
+            int currentMetadataBlockEpoch,
+            int currentMetadataTxEpoch,
+            int previousMetadataBlockEpoch,
+            int previousMetadataTxEpoch,
+            int latestBlockEpoch,
+            int latestTxEpoch,
+            string txEpochName)
         {
-                if (currentMetadataEpoch == latestEpoch)
+                if (currentMetadataTxEpoch == latestTxEpoch)
                 {
-                    jsonObject.Add(epochName, previousMetadataEpoch);
+                    if (currentMetadataBlockEpoch != latestBlockEpoch)
+                    {
+                        jsonObject.Add(txEpochName, currentMetadataTxEpoch);
+                    }
+                    else
+                    {
+                        jsonObject.Add(txEpochName, previousMetadataTxEpoch);
+                    }
                 }
                 else
                 {
-                    jsonObject.Add(epochName, currentMetadataEpoch);
+                    jsonObject.Add(txEpochName, currentMetadataTxEpoch);
+                }
+
+            return jsonObject;
+        }
+
+        private static JObject AddPreviousBlockEpoch(
+            JObject jsonObject,
+            int currentMetadataBlockEpoch,
+            int currentMetadataTxEpoch,
+            int previousMetadataBlockEpoch,
+            int previousMetadataTxEpoch,
+            int latestBlockEpoch,
+            int latestTxEpoch,
+            string blockEpochName)
+        {
+                if (currentMetadataBlockEpoch == latestBlockEpoch)
+                {
+                    if (currentMetadataTxEpoch != latestTxEpoch)
+                    {
+                        jsonObject.Add(blockEpochName, currentMetadataBlockEpoch);
+                    }
+                    else
+                    {
+                        jsonObject.Add(blockEpochName, previousMetadataBlockEpoch);
+                    }
+                }
+                else
+                {
+                    jsonObject.Add(blockEpochName, currentMetadataBlockEpoch);
                 }
 
             return jsonObject;

--- a/Program.cs
+++ b/Program.cs
@@ -147,7 +147,6 @@ namespace NineChronicles.Snapshot
                     Directory.Delete(stagedTxPath, true);
                 }
 
-                // block & tx 짜르기
                 var blockPath = Path.Combine(workingDirectory, "block");
                 var txPath = Path.Combine(workingDirectory, "tx");
                 CleanEpoch(blockPath, metadataBlockEpoch, latestBlockEpoch);
@@ -259,6 +258,7 @@ namespace NineChronicles.Snapshot
                 return 0;
             }
         }
+
         private static Block<T> GetLastestBlockWithTransaction<T>(Block<T> tip, RocksDBStore store)
             where T : DummyAction, new()
         {
@@ -272,6 +272,7 @@ namespace NineChronicles.Snapshot
             }
             return block;
         }
+
         private static void CloneDirectory(string source, string dest)
         {
             foreach (var directory in Directory.GetDirectories(source))

--- a/Program.cs
+++ b/Program.cs
@@ -316,7 +316,7 @@ namespace NineChronicles.Snapshot
                 {
                     string dirName = new DirectoryInfo(dir).Name;
                     int epoch = Int32.Parse(dirName.Substring(5));
-                    if (epoch < currentMetadataEpoch)
+                    if (epoch < currentMetadataEpoch - 1)
                     {
                         Directory.Delete(dir, true);
                     }

--- a/Program.cs
+++ b/Program.cs
@@ -146,8 +146,8 @@ namespace NineChronicles.Snapshot
 
                 var blockPath = Path.Combine(workingDirectory, "block");
                 var txPath = Path.Combine(workingDirectory, "tx");
-                CleanEpoch(blockPath, currentMetadataBlockEpoch, latestBlockEpoch);
-                CleanEpoch(txPath, currentMetadataTxEpoch, latestTxEpoch);
+                CleanEpoch(blockPath, currentMetadataBlockEpoch);
+                CleanEpoch(txPath, currentMetadataTxEpoch);
 
                 ZipFile.CreateFromDirectory(workingDirectory, snapshotPath);
                 if (snapshotTipDigest is null)
@@ -163,7 +163,6 @@ namespace NineChronicles.Snapshot
                     currentMetadataBlockEpoch,
                     currentMetadataTxEpoch,
                     previousMetadataBlockEpoch,
-                    previousMetadataTxEpoch,
                     latestBlockEpoch,
                     latestTxEpoch,
                     "PreviousBlockEpoch");
@@ -171,7 +170,6 @@ namespace NineChronicles.Snapshot
                     jsonObject,
                     currentMetadataBlockEpoch,
                     currentMetadataTxEpoch,
-                    previousMetadataBlockEpoch,
                     previousMetadataTxEpoch,
                     latestBlockEpoch,
                     latestTxEpoch,
@@ -303,7 +301,7 @@ namespace NineChronicles.Snapshot
             }
         }
 
-        private static void CleanEpoch(string path, int currentMetadataEpoch, int latestEpoch)
+        private static void CleanEpoch(string path, int currentMetadataEpoch)
         {
             string[] directories = Directory.GetDirectories(
                 path,
@@ -315,7 +313,7 @@ namespace NineChronicles.Snapshot
                 {
                     string dirName = new DirectoryInfo(dir).Name;
                     int epoch = Int32.Parse(dirName.Substring(5));
-                    if (epoch < currentMetadataEpoch - 1)
+                    if (epoch <= currentMetadataEpoch)
                     {
                         Directory.Delete(dir, true);
                     }
@@ -327,11 +325,9 @@ namespace NineChronicles.Snapshot
             }
         }
 
-        private static JObject AddPreviousTxEpoch(
-            JObject jsonObject,
+        private static JObject AddPreviousTxEpoch(JObject jsonObject,
             int currentMetadataBlockEpoch,
             int currentMetadataTxEpoch,
-            int previousMetadataBlockEpoch,
             int previousMetadataTxEpoch,
             int latestBlockEpoch,
             int latestTxEpoch,
@@ -356,12 +352,10 @@ namespace NineChronicles.Snapshot
                 return jsonObject;
         }
 
-        private static JObject AddPreviousBlockEpoch(
-            JObject jsonObject,
+        private static JObject AddPreviousBlockEpoch(JObject jsonObject,
             int currentMetadataBlockEpoch,
             int currentMetadataTxEpoch,
             int previousMetadataBlockEpoch,
-            int previousMetadataTxEpoch,
             int latestBlockEpoch,
             int latestTxEpoch,
             string blockEpochName)

--- a/Program.cs
+++ b/Program.cs
@@ -129,29 +129,8 @@ namespace NineChronicles.Snapshot
 
             var snapshotFilename = $"snapshot-{latestBlockEpoch}-{latestTxEpoch}.zip";
             var snapshotPath = Path.Combine(outputDirectory, snapshotFilename);
-            if (File.Exists(snapshotPath))
-            {
-                File.Delete(snapshotPath);
-            }
-
-            var blockPerceptPath = Path.Combine(storePath, "blockpercept");
-            if (Directory.Exists(blockPerceptPath))
-            {
-                Directory.Delete(blockPerceptPath, true);
-            }
-
-            var stagedTxPath = Path.Combine(storePath, "stagedtx");
-            if (Directory.Exists(stagedTxPath))
-            {
-                Directory.Delete(stagedTxPath, true);
-            }
-
             string workingDirectory = Path.Combine(Path.GetTempPath(), "snapshot");
-            if (Directory.Exists(workingDirectory))
-            {
-                Directory.Delete(workingDirectory, true);
-            }
-
+            CleanStore(snapshotPath, storePath, workingDirectory);
             CloneDirectory(storePath, workingDirectory);
 
             var blockPath = Path.Combine(workingDirectory, "block");
@@ -197,6 +176,31 @@ namespace NineChronicles.Snapshot
 
             File.WriteAllText(metadataPath, jsonString);
             Directory.Delete(workingDirectory, true);
+        }
+
+        private void CleanStore(string snapshotPath, string storePath, string workingDirectory)
+        {
+             if (File.Exists(snapshotPath))
+             {
+                 File.Delete(snapshotPath);
+             }
+ 
+             var blockPerceptPath = Path.Combine(storePath, "blockpercept");
+             if (Directory.Exists(blockPerceptPath))
+             {
+                 Directory.Delete(blockPerceptPath, true);
+             }
+ 
+             var stagedTxPath = Path.Combine(storePath, "stagedtx");
+             if (Directory.Exists(stagedTxPath))
+             {
+                 Directory.Delete(stagedTxPath, true);
+             }
+ 
+             if (Directory.Exists(workingDirectory))
+             {
+                 Directory.Delete(workingDirectory, true);
+             }           
         }
 
         private void Fork(

--- a/Program.cs
+++ b/Program.cs
@@ -91,8 +91,8 @@ namespace NineChronicles.Snapshot
                 var snapshotTipIndex = Math.Max(tipIndex - (blockBefore + 1), 0);
                 HashDigest<SHA256> snapshotTipHash;
 
+                var latestBlockEpoch = (int)(tip.Timestamp.ToUnixTimeSeconds() / 86400);
                 var latestBlockWithTx = GetLastestBlockWithTransaction<DummyAction>(tip, _store);
-                var latestBlockEpoch = (int)(latestBlockWithTx.Timestamp.ToUnixTimeSeconds() / 86400);
                 var txTimeSecond = latestBlockWithTx.Transactions.Max(tx => tx.Timestamp.ToUnixTimeSeconds());
                 var latestTxEpoch = (int)(txTimeSecond / 86400);
 
@@ -128,7 +128,7 @@ namespace NineChronicles.Snapshot
 
                 var genesisHashHex = ByteUtil.Hex(genesisHash.ToByteArray());
                 var snapshotTipHashHex = ByteUtil.Hex(snapshotTipHash.ToByteArray());
-                var snapshotFilename = $"{genesisHashHex}-snapshot-{snapshotTipHashHex}.zip";
+                var snapshotFilename = $"{genesisHashHex}-snapshot-{latestBlockEpoch}-{latestTxEpoch}.zip";
                 var snapshotPath = Path.Combine(outputDirectory, snapshotFilename);
                 if (File.Exists(snapshotPath))
                 {
@@ -166,7 +166,7 @@ namespace NineChronicles.Snapshot
                 jsonObject.Add("TxEpoch", latestTxEpoch);
                 var jsonString = JsonConvert.SerializeObject(jsonObject);
 
-                var metadataFilename = $"{genesisHashHex}-snapshot-{snapshotTipHashHex}.json";
+                var metadataFilename = $"{genesisHashHex}-snapshot-{latestBlockEpoch}-{latestTxEpoch}.json";
                 var metadataPath = Path.Combine(outputDirectory, metadataFilename);
                 if (File.Exists(metadataPath))
                 {

--- a/Program.cs
+++ b/Program.cs
@@ -110,7 +110,7 @@ namespace NineChronicles.Snapshot
                 const int blockEpochUnitSeconds = 86400;
                 const int txEpochUnitSeconds = 86400;
                 var latestBlockEpoch = (int)(tip.Timestamp.ToUnixTimeSeconds() / blockEpochUnitSeconds);
-                var latestBlockWithTx = GetLastestBlockWithTransaction<DummyAction>(tip, _store);
+                var latestBlockWithTx = GetLatestBlockWithTransaction<DummyAction>(tip, _store);
                 var txTimeSecond = latestBlockWithTx.Transactions.Max(tx => tx.Timestamp.ToUnixTimeSeconds());
                 var latestTxEpoch = (int)(txTimeSecond / txEpochUnitSeconds );
 
@@ -271,7 +271,7 @@ namespace NineChronicles.Snapshot
             }
         }
 
-        private static Block<T> GetLastestBlockWithTransaction<T>(Block<T> tip, RocksDBStore store)
+        private static Block<T> GetLatestBlockWithTransaction<T>(Block<T> tip, RocksDBStore store)
             where T : DummyAction, new()
         {
             var block = tip;
@@ -353,7 +353,7 @@ namespace NineChronicles.Snapshot
                     jsonObject.Add(txEpochName, currentMetadataTxEpoch);
                 }
 
-            return jsonObject;
+                return jsonObject;
         }
 
         private static JObject AddPreviousBlockEpoch(
@@ -382,7 +382,7 @@ namespace NineChronicles.Snapshot
                     jsonObject.Add(blockEpochName, currentMetadataBlockEpoch);
                 }
 
-            return jsonObject;
+                return jsonObject;
         }
 
         private class DummyAction : IAction

--- a/Program.cs
+++ b/Program.cs
@@ -46,21 +46,20 @@ namespace NineChronicles.Snapshot
                 "9c"
             );
 
-            if (!Directory.Exists(outputDirectory))
-            {
-                Directory.CreateDirectory(outputDirectory);
-                Directory.CreateDirectory(outputDirectory + "/partition");
-                Directory.CreateDirectory(outputDirectory + "/state");
-            }
+            Directory.CreateDirectory(outputDirectory);
+            Directory.CreateDirectory(outputDirectory + "/partition");
+            Directory.CreateDirectory(outputDirectory + "/state");
+            Directory.CreateDirectory(outputDirectory + "/metadata");
 
             outputDirectory = string.IsNullOrEmpty(outputDirectory)
                 ? Environment.CurrentDirectory
                 : outputDirectory;
 
-            int currentMetadataBlockEpoch = GetMetaDataEpoch(outputDirectory, "BlockEpoch");
-            int currentMetadataTxEpoch = GetMetaDataEpoch(outputDirectory, "TxEpoch");
-            int previousMetadataBlockEpoch = GetMetaDataEpoch(outputDirectory, "PreviousBlockEpoch");
-            int previousMetadataTxEpoch = GetMetaDataEpoch(outputDirectory, "PreviousTxEpoch");
+            var metadataDirectory = Path.Combine(outputDirectory, "metadata");
+            int currentMetadataBlockEpoch = GetMetaDataEpoch(metadataDirectory, "BlockEpoch");
+            int currentMetadataTxEpoch = GetMetaDataEpoch(metadataDirectory, "TxEpoch");
+            int previousMetadataBlockEpoch = GetMetaDataEpoch(metadataDirectory, "PreviousBlockEpoch");
+            int previousMetadataTxEpoch = GetMetaDataEpoch(metadataDirectory, "PreviousTxEpoch");
 
             storePath = string.IsNullOrEmpty(storePath) ? defaultStorePath : storePath;
             if (!Directory.Exists(storePath))
@@ -176,7 +175,7 @@ namespace NineChronicles.Snapshot
                 latestBlockEpoch,
                 latestTxEpoch);
             var metadataFilename = $"{partitionBaseFilename}.json";
-            var metadataPath = Path.Combine(outputDirectory, metadataFilename);
+            var metadataPath = Path.Combine(metadataDirectory, metadataFilename);
             if (File.Exists(metadataPath))
             {
                 File.Delete(metadataPath);

--- a/Program.cs
+++ b/Program.cs
@@ -307,20 +307,43 @@ namespace NineChronicles.Snapshot
             {
             Directory.Delete(chainPath, true);
             }
+
+            var blockPath = Path.Combine(partitionDirectory, "block");
+            var blockIndexPath = Path.Combine(blockPath, "blockindex");
+            if (Directory.Exists(blockIndexPath))
+            {
+            Directory.Delete(blockIndexPath, true);
+            }
+
+            var txPath = Path.Combine(partitionDirectory, "tx");
+            var txIndexPath = Path.Combine(txPath, "txindex");
+            if (Directory.Exists(txIndexPath))
+            {
+            Directory.Delete(txIndexPath, true);
+            }
         }
 
         private void CleanStateStore(string stateDirectory)
         {
             var blockPath = Path.Combine(stateDirectory, "block");
-            if (Directory.Exists(blockPath))
+            var txPath = Path.Combine(stateDirectory, "tx");
+            string[] blockDirectories = Directory.GetDirectories(
+                blockPath,
+                "epoch*",
+                SearchOption.AllDirectories);
+            string[] txDirectories = Directory.GetDirectories(
+                txPath,
+                "epoch*",
+                SearchOption.AllDirectories);
+
+            foreach (string dir in blockDirectories)
             {
-                Directory.Delete(blockPath, true);
+                Directory.Delete(dir, true);
             }
 
-            var txPath = Path.Combine(stateDirectory, "tx");
-            if (Directory.Exists(txPath))
+            foreach (string dir in txDirectories)
             {
-                Directory.Delete(txPath, true);
+                Directory.Delete(dir, true);
             }
         }
 
@@ -443,7 +466,7 @@ namespace NineChronicles.Snapshot
                 {
                     string dirName = new DirectoryInfo(dir).Name;
                     int epoch = Int32.Parse(dirName.Substring(5));
-                    if (epoch + 1 < epochLimit)
+                    if (epoch < epochLimit)
                     {
                         Directory.Delete(dir, true);
                     }

--- a/Program.cs
+++ b/Program.cs
@@ -254,7 +254,7 @@ namespace NineChronicles.Snapshot
             }
         }
 
-        private static int GetMetaDataEpoch(
+        private int GetMetaDataEpoch(
             string outputDirectory,
             string epochType)
         {
@@ -274,7 +274,7 @@ namespace NineChronicles.Snapshot
             }
         }
 
-        private static Block<T> GetLatestBlockWithTransaction<T>(Block<T> tip, RocksDBStore store)
+        private Block<T> GetLatestBlockWithTransaction<T>(Block<T> tip, RocksDBStore store)
             where T : DummyAction, new()
         {
             var block = tip;
@@ -288,7 +288,7 @@ namespace NineChronicles.Snapshot
             return block;
         }
 
-        private static void CloneDirectory(string source, string dest)
+        private void CloneDirectory(string source, string dest)
         {
             foreach (var directory in Directory.GetDirectories(source))
             {
@@ -306,7 +306,7 @@ namespace NineChronicles.Snapshot
             }
         }
 
-        private static void CleanEpoch(string path, int currentMetadataEpoch)
+        private void CleanEpoch(string path, int currentMetadataEpoch)
         {
             string[] directories = Directory.GetDirectories(
                 path,
@@ -330,7 +330,7 @@ namespace NineChronicles.Snapshot
             }
         }
 
-        private static JObject AddPreviousTxEpoch(JObject jsonObject,
+        private JObject AddPreviousTxEpoch(JObject jsonObject,
             int currentMetadataBlockEpoch,
             int currentMetadataTxEpoch,
             int previousMetadataTxEpoch,
@@ -357,7 +357,7 @@ namespace NineChronicles.Snapshot
                 return jsonObject;
         }
 
-        private static JObject AddPreviousBlockEpoch(JObject jsonObject,
+        private JObject AddPreviousBlockEpoch(JObject jsonObject,
             int currentMetadataBlockEpoch,
             int currentMetadataTxEpoch,
             int previousMetadataBlockEpoch,

--- a/README.md
+++ b/README.md
@@ -13,13 +13,12 @@
 
 ```
 $ dotnet run -- --help
-Usage: Snapshot [--store-path <String>] [--working-directory <String>] [--output-directory <String>] [--block-before <Int32>] [--apv <String>] [--help] [--version]
+Usage: Snapshot [--store-path <String>] [--output-directory <String>] [--block-before <Int32>] [--apv <String>] [--help] [--version]
 
 Snapshot
 
 Options:
   --apv <String>                      (Required)
-  --working-directory <String>        (Required)
   -o, --output-directory <String>     (Default: )
   --store-path <String>               (Default: )
   --block-before <Int32>              (Default: 10)

--- a/README.md
+++ b/README.md
@@ -13,12 +13,13 @@
 
 ```
 $ dotnet run -- --help
-Usage: Snapshot [--output-directory <String>] [--store-path <String>] [--block-before <Int32>] [--apv <String>] [--help] [--version]
+Usage: Snapshot [--store-path <String>] [--working-directory <String>] [--output-directory <String>] [--block-before <Int32>] [--apv <String>] [--help] [--version]
 
 Snapshot
 
 Options:
   --apv <String>                      (Required)
+  --working-directory <String>        (Required)
   -o, --output-directory <String>     (Default: )
   --store-path <String>               (Default: )
   --block-before <Int32>              (Default: 10)


### PR DESCRIPTION
This PR:
1. Takes the `json` metadata in the `--output-directory` and finds `BlockEpoch` & `TxEpoch` (saved as `metadataBlockEpoch` & `metadataTxEpoch`).
2. Copies the chain data from the `--output-directory` to the `--working-directory`.
3. Finds the `latestBlockEpoch` and `latestTxEpoch` in the `--working-directory` chain.
4. Deletes all epoch directories before `metadataBlockEpoch` & `metadataTxEpoch`.
5. Zips snapshot.

**Original Chain Data after Preload**
![Screen Shot 2021-03-08 at 9 41 35 PM](https://user-images.githubusercontent.com/42176649/110323499-06883800-8058-11eb-8cdc-dac79856006f.png)

**Snapshot (when BlockEpoch & TxEpoch = 18655)**
![Screen Shot 2021-03-08 at 9 42 58 PM](https://user-images.githubusercontent.com/42176649/110323529-0daf4600-8058-11eb-9666-7e04333f3ceb.png)

**Metadata (used for determining previous Epoch)**
![Screen Shot 2021-03-08 at 9 46 51 PM](https://user-images.githubusercontent.com/42176649/110323464-fcfed000-8057-11eb-944c-92e54048de39.png)

**New Metadata (after creating snapshot)**
![Screen Shot 2021-03-08 at 9 52 33 PM](https://user-images.githubusercontent.com/42176649/110323846-82828000-8058-11eb-99f9-239ba3edfb18.png)
