### PR TITLE
Bug fix/modify clean epoch

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -181,7 +181,7 @@ namespace NineChronicles.Snapshot
                 throw new CommandExitedException("Tip does not exist.", -1);
             }
 
-            string stringfyMetadata = GetMetadata(
+            string stringfyMetadata = CreateMetadata(
                 snapshotTipDigest.Value,
                 apv,
                 currentMetadataBlockEpoch,
@@ -202,7 +202,7 @@ namespace NineChronicles.Snapshot
             Directory.Delete(stateDirectory, true);
         }
 
-        private string GetMetadata(
+        private string CreateMetadata(
             BlockDigest snapshotTipDigest,
             string apv,
             int currentMetadataBlockEpoch,

--- a/Program.cs
+++ b/Program.cs
@@ -153,23 +153,20 @@ namespace NineChronicles.Snapshot
 
             var blockPath = Path.Combine(partitionDirectory, "block");
             var txPath = Path.Combine(partitionDirectory, "tx");
-            if (currentMetadataBlockEpoch == latestBlockEpoch)
-            {
-                CleanEpoch(blockPath, previousMetadataBlockEpoch);
-            }
-            else
-            {
-                CleanEpoch(blockPath, currentMetadataBlockEpoch);
-            }
 
-            if (currentMetadataTxEpoch == latestTxEpoch)
-            {
-                CleanEpoch(txPath, previousMetadataTxEpoch);
-            }
-            else
-            {
-                CleanEpoch(txPath, currentMetadataTxEpoch);
-            }
+            // get epoch limit for block & tx
+            var blockEpochLimit = GetEpochLimit(
+                latestBlockEpoch,
+                currentMetadataBlockEpoch,
+                previousMetadataBlockEpoch);
+            var txEpochLimit = GetEpochLimit(
+                latestTxEpoch,
+                currentMetadataTxEpoch,
+                previousMetadataTxEpoch);
+
+            // clean epoch directories in block & tx
+            CleanEpoch(blockPath, blockEpochLimit);
+            CleanEpoch(txPath, txEpochLimit);
 
             CleanPartitionStore(partitionDirectory);
             CleanStateStore(stateDirectory);
@@ -200,6 +197,37 @@ namespace NineChronicles.Snapshot
             File.WriteAllText(metadataPath, stringfyMetadata);
             Directory.Delete(partitionDirectory, true);
             Directory.Delete(stateDirectory, true);
+        }
+
+        private int GetEpochLimit(
+            int latestEpoch,
+            int currentMetadataEpoch,
+            int previousMetadataEpoch
+        )
+        {
+            if (latestEpoch == currentMetadataEpoch)
+            {
+                // case when all epochs are the same
+                if (latestEpoch == previousMetadataEpoch)
+                {
+                    // return previousMetadataEpoch - 1
+                    // to save previous epoch in snapshot
+                    return previousMetadataEpoch - 1;
+                }
+                // case when metadata points to genesis snapshot
+                else if (previousMetadataEpoch == 0)
+                {
+                    return currentMetadataEpoch - 1;
+                }
+                else
+                {
+                    return previousMetadataEpoch;
+                }
+            }
+            else
+            {
+                return currentMetadataEpoch;
+            }
         }
 
         private string CreateMetadata(


### PR DESCRIPTION
새로운 스냅샷을 찍을때, 이전 스냅샷 메타데이터의 `previousEpoch`, `currentEpoch`과 현재 스토어의 `latestEpoch`이 모두 같을 경우 `previousEpoch - 1` 값을 기준값으로 설정하여 새 스냅샷에 이전 epoch을 포함해서 찍을 수 있도록 수정되었습니다.

Before:
`previousEpoch` : 3, `currentEpoch`: 3, `latestEpoch`: 3 => 새로 찍힌 스냅샷의 epoch: 3

Now: 
`previousEpoch` : 3, `currentEpoch`: 3, `latestEpoch`: 3 => 새로 찍힌 스냅샷의 epoch: 2, 3