### PR TITLE
remove txexec when taking snapshot

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -340,6 +340,7 @@ namespace NineChronicles.Snapshot
                 Path.Combine(partitionDirectory, "stateref"),
                 Path.Combine(partitionDirectory, "states"),
                 Path.Combine(partitionDirectory, "chain"),
+                Path.Combine(partitionDirectory, "txexec"),
                 Path.Combine(partitionDirectory, "block", "blockindex"),
                 Path.Combine(partitionDirectory, "tx", "txindex"),
             };
@@ -357,6 +358,7 @@ namespace NineChronicles.Snapshot
         {
             var blockPath = Path.Combine(stateDirectory, "block");
             var txPath = Path.Combine(stateDirectory, "tx");
+            var txExecPath = Path.Combine(stateDirectory, "txexec");
             string[] blockDirectories = Directory.GetDirectories(
                 blockPath,
                 "epoch*",
@@ -375,6 +377,8 @@ namespace NineChronicles.Snapshot
             {
                 Directory.Delete(dir, true);
             }
+
+            Directory.Delete(txExecPath, true);
         }
 
         private void Fork(


### PR DESCRIPTION
This PR removes `txexec` in both `partition-snapshot` and `state-latest` before zipping.