### PR TITLE
Revert prune cf

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -14,7 +14,6 @@ using Libplanet.Store;
 using Libplanet.Store.Trie;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
-using RocksDbSharp;
 
 namespace NineChronicles.Snapshot
 {
@@ -69,8 +68,6 @@ namespace NineChronicles.Snapshot
 
             var statesPath = Path.Combine(storePath, "states");
             var stateHashesPath = Path.Combine(storePath, "state_hashes");
-
-            PruneOutdatedColumnFamilies(Path.Combine(storePath, "chain"));
 
             _store = new RocksDBStore(
                 storePath,
@@ -203,68 +200,6 @@ namespace NineChronicles.Snapshot
             File.WriteAllText(metadataPath, stringfyMetadata);
             Directory.Delete(partitionDirectory, true);
             Directory.Delete(stateDirectory, true);
-        }
-
-        private void PruneOutdatedColumnFamilies(string path)
-        {
-            var opt = new DbOptions();
-            List<string> cfns = RocksDb.ListColumnFamilies(opt, path).ToList();
-            var cfs = new ColumnFamilies();
-            foreach (string name in cfns)
-            {
-                cfs.Add(name, opt);
-            }
-
-            using RocksDb db = RocksDb.Open(opt, path, cfs);
-            var ccid = new Guid(db.Get(new[] { (byte)'C' }));
-            ColumnFamilyHandle ccf = db.GetColumnFamily(ccid.ToString());
-
-            ColumnFamilyHandle PreviousColumnFamily(ColumnFamilyHandle cfh)
-            {
-                byte[] cid = db.Get(new[] { (byte)'P' }, cfh);
-
-                if (cid is null)
-                {
-                    return null;
-                }
-                else
-                {
-                    return db.GetColumnFamily(new Guid(cid).ToString());
-                }
-            }
-
-            ColumnFamilyHandle cf = PreviousColumnFamily(ccf);
-            var ip = new[] { (byte)'I' };
-            var batch = new WriteBatch();
-            while (!(cf is null))
-            {
-                Iterator it = db.NewIterator(cf);
-                for (it.Seek(ip); it.Valid() && it.Key().StartsWith(ip); it.Next())
-                {
-                    batch.Put(it.Key(), it.Value(), ccf);
-
-                    if (batch.Count() > 10000)
-                    {
-                        db.Write(batch);
-                        batch.Clear();
-                    }
-                }
-
-                cf = PreviousColumnFamily(cf);
-            }
-
-            db.Write(batch);
-
-            foreach (string name in cfns)
-            {
-                if (name == ccid.ToString() || name == "default")
-                {
-                    continue;
-                }
-                db.DropColumnFamily(name);
-            }
-
-            db.Remove(new[] { (byte)'P' }, ccf);
         }
 
         private string GetPartitionBaseFileName(

--- a/Program.cs
+++ b/Program.cs
@@ -68,6 +68,12 @@ namespace NineChronicles.Snapshot
 
             var statesPath = Path.Combine(storePath, "states");
             var stateHashesPath = Path.Combine(storePath, "state_hashes");
+            var txexecPath = Path.Combine(storePath, "txexec");
+
+            if (Directory.Exists(txexecPath))
+            {
+                Directory.Delete(txexecPath, true);
+            }
 
             _store = new RocksDBStore(
                 storePath,


### PR DESCRIPTION
This PR temporarily reverts https://github.com/planetarium/NineChronicles.Snapshot/commit/c0501dc58791e2a8c543cf358144cc3ae22bd4d7 which is possibly causing the following error in RocksDBStore:
```
[11:01:36 ERR] An exception occurred during appending blocks: Libplanet.Tx.InvalidTxNonceException: 42ea4dfdee1c67589e8f67cec16b5a3855ac9cdbf08b7d3fff156602ed3e0185: Transaction nonce is invalid.
Expected nonce: 535
Improper nonce: 534
   at Libplanet.Blockchain.BlockChain`1.Append(Block`1 block, DateTimeOffset currentTime, Boolean evaluateActions, Boolean renderBlocks, Boolean renderActions, IReadOnlyList`1 actionEvaluations, Nullable`1 stateCompleters) in /app/Lib9c/.Libplanet/Libplanet/Blockchain/BlockChain.cs:line 1191
   at Libplanet.Net.Swarm`1.PreloadAsync(Nullable`1 dialTimeout, IProgress`1 progress, CancellationToken cancellationToken) in /app/Lib9c/.Libplanet/Libplanet/Net/Swarm.cs:line 777
Libplanet.Tx.InvalidTxNonceException: 42ea4dfdee1c67589e8f67cec16b5a3855ac9cdbf08b7d3fff156602ed3e0185: Transaction nonce is invalid.
Expected nonce: 535
Improper nonce: 534
   at Libplanet.Blockchain.BlockChain`1.Append(Block`1 block, DateTimeOffset currentTime, Boolean evaluateActions, Boolean renderBlocks, Boolean renderActions, IReadOnlyList`1 actionEvaluations, Nullable`1 stateCompleters) in /app/Lib9c/.Libplanet/Libplanet/Blockchain/BlockChain.cs:line 1191
   at Libplanet.Net.Swarm`1.PreloadAsync(Nullable`1 dialTimeout, IProgress`1 progress, CancellationToken cancellationToken) in /app/Lib9c/.Libplanet/Libplanet/Net/Swarm.cs:line 777
```