### PR TITLE
Introduce snapshot-type option

### DIFF
--- a/NineChronicles.Snapshot.csproj
+++ b/NineChronicles.Snapshot.csproj
@@ -8,8 +8,8 @@
 
   <ItemGroup>
     <PackageReference Include="Cocona.Lite" Version="1.3.0" />
-    <PackageReference Include="Libplanet" Version="0.20.0" />
-    <PackageReference Include="Libplanet.RocksDBStore" Version="0.20.0" />
+    <PackageReference Include="Libplanet" Version="0.20.2" />
+    <PackageReference Include="Libplanet.RocksDBStore" Version="0.20.2" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
   </ItemGroup>
 

--- a/Program.cs
+++ b/Program.cs
@@ -206,6 +206,7 @@ namespace NineChronicles.Snapshot
                 stateDirectory);
             if (snapshotType == "partition" || snapshotType == "all")
             {
+                CloneDirectory(storePath, partitionDirectory);
                 CloneDirectory(storePath, stateDirectory);
                 var blockPath = Path.Combine(partitionDirectory, "block");
                 var txPath = Path.Combine(partitionDirectory, "tx");

--- a/Program.cs
+++ b/Program.cs
@@ -82,7 +82,7 @@ namespace NineChronicles.Snapshot
             var txexecPath = Path.Combine(storePath, "txexec");
 
             var staleDirectories =
-            new [] { mainPath, statePath, statesPath, stateRefPath, stateHashesPath, txexecPath };
+            new [] { mainPath, statePath, stateRefPath, stateHashesPath, txexecPath };
             foreach (var staleDirectory in staleDirectories)
             {
                 if (Directory.Exists(staleDirectory))

--- a/README.md
+++ b/README.md
@@ -11,9 +11,11 @@
 *https://9c-test.s3.ap-northeast-2.amazonaws.com/latest/{genesisHash}-snapshot.json*
 경로에 업로드 해야 합니다.
 
+`--snapshot-type` 옵션을 사용하는 경우, default로 증분 스냅샷이 찍힙니다. 옵션 값으로 `full`을 사용하면, 통 스냅샷으로 찍히며 `all`을 사용하면 증분 & 통 스냅샷이 모두 찍힙니다.
+
 ```
 $ dotnet run -- --help
-Usage: Snapshot [--store-path <String>] [--output-directory <String>] [--block-before <Int32>] [--apv <String>] [--help] [--version]
+Usage: Snapshot [--store-path <String>] [--output-directory <String>] [--block-before <Int32>] [--apv <String>] [--snapshot-type <String>] [--help] [--version]
 
 Snapshot
 
@@ -22,6 +24,7 @@ Options:
   -o, --output-directory <String>     (Default: )
   --store-path <String>               (Default: )
   --block-before <Int32>              (Default: 10)
+  --snapshot-type <String>            (Default: partition)
   -h, --help                         Show help message
   --version                          Show version
 ```


### PR DESCRIPTION
Previously, the snapshot node created both partition & full snapshots.

This caused the snapshot job to take very long (40+ min).

Therefore, I've created a `snapshot-type` option so that users can choose to create either `partition`, `full`, or `all`(both) snapshots.

## Usage
- Full
```
NineChronicles.Snapshot --snapshot-type "full" --output-directory "$OUTPUT_DIR" --store-path "$STORE_PATH"  --block-before 50 --apv "$APV"
```
- Partition
```
NineChronicles.Snapshot --snapshot-type "partition" --output-directory "$OUTPUT_DIR" --store-path "$STORE_PATH"  --block-before 50 --apv "$APV"
```
- Both
```
NineChronicles.Snapshot --snapshot-type "all" --output-directory "$OUTPUT_DIR" --store-path "$STORE_PATH"  --block-before 50 --apv "$APV"
```