### PR TITLE
Improve performance

### DIFF
--- a/NineChronicles.Snapshot.csproj
+++ b/NineChronicles.Snapshot.csproj
@@ -8,8 +8,8 @@
 
   <ItemGroup>
     <PackageReference Include="Cocona.Lite" Version="1.3.0" />
-    <PackageReference Include="Libplanet" Version="0.26.0" />
-    <PackageReference Include="Libplanet.RocksDBStore" Version="0.26.0" />
+    <PackageReference Include="Libplanet" Version="0.27.0-dev.20220121093803" />
+    <PackageReference Include="Libplanet.RocksDBStore" Version="0.27.0-dev.20220121093803" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
   </ItemGroup>
 


### PR DESCRIPTION
This pull request does:

- Use `TrieStateStore.CopyStates()` method instead of `TrieStateStore.PruneStates()`.
- Run snapshot steps in parallel.