### PR TITLE
change tx epochlimit to the same value as block epochlimit

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -214,7 +214,7 @@ namespace NineChronicles.Snapshot
 
                         // clean epoch directories in block & tx
                         CleanEpoch(blockPath, blockEpochLimit);
-                        CleanEpoch(txPath, txEpochLimit);
+                        CleanEpoch(txPath, blockEpochLimit);
                     }),
                     Task.Run(() =>
                     {


### PR DESCRIPTION
Given that partition snapshots are taken every hour, this fix partitions the `tx` directory in the same way as the `block` directory for consistency. Also, there are some cases when txs are partitioned incorrectly, which breaks the blockchain store and this fix amends that case.