### PR TITLE
fix) dispose newStateKeyValueStore

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -162,6 +162,7 @@ namespace NineChronicles.Snapshot
 
             _store.Dispose();
             _stateStore.Dispose();
+            newStateKeyValueStore.Dispose();
 
             Directory.Delete(statesPath, recursive: true);
             Directory.Move(newStatesPath, statesPath);


### PR DESCRIPTION
Adding `newStateKeyValueStore.Dispose();` to take care of the error that occurs in a local environment (this error doesn't occur in Docker for unknown reasons):
```
Unhandled Exception: System.IO.IOException: Access to the path 'C:\Users\lime\planetarium\local-test\9c-main-partition-old\new_states' is denied.
   at Cocona.Command.Dispatcher.Middlewares.CoconaCommandInvokeMiddleware.DispatchAsync(CommandDispatchContext ctx)
   at Cocona.Command.Dispatcher.Middlewares.HandleParameterBindExceptionMiddleware.DispatchAsync(CommandDispatchContext ctx)
   at Cocona.Command.Dispatcher.Middlewares.HandleExceptionAndExitMiddleware.DispatchAsync(CommandDispatchContext ctx)
   at Cocona.Command.Dispatcher.CoconaCommandDispatcher.DispatchAsync(CancellationToken cancellationToken)
   at Cocona.Lite.Hosting.CoconaLiteAppHost.RunAsyncCore(CancellationToken cancellationToken)
```