### PR TITLE
fix eviction & add temporary logging

### DIFF
--- a/.github/workflows/push_docker_image.yml
+++ b/.github/workflows/push_docker_image.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - main
-      - v120-fix
+      - v120-logger
 
 jobs:
   build_and_push:

--- a/.github/workflows/push_docker_image.yml
+++ b/.github/workflows/push_docker_image.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - main
-      - mono
+      - v120-fix
 
 jobs:
   build_and_push:

--- a/.github/workflows/push_docker_image.yml
+++ b/.github/workflows/push_docker_image.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - main
-      - v120-logger
+      - v140-logger
 
 jobs:
   build_and_push:

--- a/.github/workflows/push_docker_image.yml
+++ b/.github/workflows/push_docker_image.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - v140-logger
 
 jobs:
   build_and_push:

--- a/NineChronicles.Snapshot.csproj
+++ b/NineChronicles.Snapshot.csproj
@@ -8,8 +8,8 @@
 
   <ItemGroup>
     <PackageReference Include="Cocona.Lite" Version="1.3.0" />
-    <PackageReference Include="Libplanet" Version="0.26.0" />
-    <PackageReference Include="Libplanet.RocksDBStore" Version="0.26.0" />
+    <PackageReference Include="Libplanet" Version="0.28.0" />
+    <PackageReference Include="Libplanet.RocksDBStore" Version="0.28.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
   </ItemGroup>
 

--- a/NineChronicles.Snapshot.csproj
+++ b/NineChronicles.Snapshot.csproj
@@ -8,8 +8,8 @@
 
   <ItemGroup>
     <PackageReference Include="Cocona.Lite" Version="1.3.0" />
-    <PackageReference Include="Libplanet" Version="0.28.0" />
-    <PackageReference Include="Libplanet.RocksDBStore" Version="0.28.0" />
+    <PackageReference Include="Libplanet" Version="0.29.0" />
+    <PackageReference Include="Libplanet.RocksDBStore" Version="0.29.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
   </ItemGroup>
 

--- a/NineChronicles.Snapshot.csproj
+++ b/NineChronicles.Snapshot.csproj
@@ -8,8 +8,8 @@
 
   <ItemGroup>
     <PackageReference Include="Cocona.Lite" Version="1.3.0" />
-    <PackageReference Include="Libplanet" Version="0.28.0" />
-    <PackageReference Include="Libplanet.RocksDBStore" Version="0.28.0" />
+    <PackageReference Include="Libplanet" Version="0.26.0" />
+    <PackageReference Include="Libplanet.RocksDBStore" Version="0.26.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
   </ItemGroup>
 

--- a/Program.cs
+++ b/Program.cs
@@ -201,9 +201,7 @@ namespace NineChronicles.Snapshot
                     partitionSnapshotPath,
                     stateSnapshotPath,
                     fullSnapshotPath,
-                    storePath,
-                    partitionDirectory,
-                    stateDirectory);
+                    storePath);
                 end = DateTimeOffset.Now;
                 Console.WriteLine("Clean Store Done. Time Taken: {0}", (end - start).Minutes);
                 if (snapshotType == SnapshotType.Partition || snapshotType == SnapshotType.All)
@@ -447,9 +445,7 @@ namespace NineChronicles.Snapshot
             string partitionSnapshotPath,
             string stateSnapshotPath,
             string fullSnapshotPath,
-            string storePath,
-            string partitionDirectory,
-            string stateDirectory)
+            string storePath)
         {
             if (File.Exists(partitionSnapshotPath))
             {
@@ -469,9 +465,7 @@ namespace NineChronicles.Snapshot
             var cleanDirectories = new[]
             {
                 Path.Combine(storePath, "blockpercept"),
-                Path.Combine(storePath, "stagedtx"),
-                partitionDirectory,
-                stateDirectory
+                Path.Combine(storePath, "stagedtx")
             };
 
             foreach (var path in cleanDirectories)

--- a/Program.cs
+++ b/Program.cs
@@ -6,6 +6,7 @@ using System.IO.Compression;
 using System.Linq;
 using System.Security.Cryptography;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using Bencodex.Types;
 using Cocona;
@@ -212,6 +213,7 @@ namespace NineChronicles.Snapshot
                     CopyDirectory(storePath, partitionDirectory, true);
                     end = DateTimeOffset.Now;
                     Console.WriteLine("Clone Partition Directory Done. Time Taken(min): {0}", (end - start).Minutes);
+                    Thread.Sleep(10000);
                     Console.WriteLine("Clone State Directory Start.");
                     start = DateTimeOffset.Now;
                     CopyDirectory(storePath, stateDirectory, true);

--- a/Program.cs
+++ b/Program.cs
@@ -222,11 +222,6 @@ namespace NineChronicles.Snapshot
                     end = DateTimeOffset.Now;
                     Console.WriteLine("Clone Partition Directory Done. Time Taken(min): {0}", (end - start).Minutes);
                     Thread.Sleep(10000);
-                    Console.WriteLine("Clone State Directory Start.");
-                    start = DateTimeOffset.Now;
-                    CopyDirectory(storePath, stateDirectory, true);
-                    end = DateTimeOffset.Now;
-                    Console.WriteLine("Clone State Directory Done. Time Taken(min): {0}", (end - start).Minutes);
                     var blockPath = Path.Combine(partitionDirectory, "block");
                     var txPath = Path.Combine(partitionDirectory, "tx");
 
@@ -240,16 +235,27 @@ namespace NineChronicles.Snapshot
                         currentMetadataTxEpoch,
                         previousMetadataTxEpoch);
 
-                    Console.WriteLine("Clean Stores Start.");
+                    Console.WriteLine("Clean Partition Store Start.");
                     start = DateTimeOffset.Now;
                     // clean epoch directories in block & tx
                     CleanEpoch(blockPath, blockEpochLimit);
                     CleanEpoch(txPath, txEpochLimit);
 
                     CleanPartitionStore(partitionDirectory);
+                    end = DateTimeOffset.Now;
+                    Console.WriteLine("Clean Partition Store Done. Time Taken(min): {0}", (end - start).Minutes);
+
+                    Console.WriteLine("Clone State Directory Start.");
+                    start = DateTimeOffset.Now;
+                    CopyDirectory(storePath, stateDirectory, true);
+                    end = DateTimeOffset.Now;
+                    Console.WriteLine("Clone State Directory Done. Time Taken(min): {0}", (end - start).Minutes);
+
+                    Console.WriteLine("Clean State Store Start.");
+                    start = DateTimeOffset.Now;
                     CleanStateStore(stateDirectory);
                     end = DateTimeOffset.Now;
-                    Console.WriteLine("Clean Stores Done. Time Taken(min): {0}", (end - start).Minutes);
+                    Console.WriteLine("Clean State Store Done. Time Taken(min): {0}", (end - start).Minutes);
                 }
                 
                 if (snapshotType == SnapshotType.Full || snapshotType == SnapshotType.All)

--- a/Program.cs
+++ b/Program.cs
@@ -197,6 +197,14 @@ namespace NineChronicles.Snapshot
                 var stateSnapshotPath = Path.Combine(outputDirectory, "state", stateSnapshotFilename);
                 string partitionDirectory = Path.Combine(Path.GetTempPath(), "snapshot");
                 string stateDirectory = Path.Combine(Path.GetTempPath(), "state");
+                if (Directory.Exists(partitionDirectory))
+                {
+                    Directory.Delete(partitionDirectory, true);
+                }
+                if (Directory.Exists(stateDirectory))
+                {
+                    Directory.Delete(stateDirectory, true);
+                }
                 Console.WriteLine("Clean Store Start.");
                 start = DateTimeOffset.Now;
                 CleanStore(
@@ -218,7 +226,7 @@ namespace NineChronicles.Snapshot
                     start = DateTimeOffset.Now;
                     CopyDirectory(storePath, stateDirectory, true);
                     end = DateTimeOffset.Now;
-                    Console.WriteLine("Clone Directory Done. Time Taken(min): {0}", (end - start).Minutes);
+                    Console.WriteLine("Clone State Directory Done. Time Taken(min): {0}", (end - start).Minutes);
                     var blockPath = Path.Combine(partitionDirectory, "block");
                     var txPath = Path.Combine(partitionDirectory, "tx");
 
@@ -617,34 +625,41 @@ namespace NineChronicles.Snapshot
 
         private void CopyDirectory(string sourceDir, string destinationDir, bool recursive)
         {
-            // Get information about the source directory
-            var dir = new DirectoryInfo(sourceDir);
-
-            // Check if the source directory exists
-            if (!dir.Exists)
-                throw new DirectoryNotFoundException($"Source directory not found: {dir.FullName}");
-
-            // Cache directories before we start copying
-            DirectoryInfo[] dirs = dir.GetDirectories();
-
-            // Create the destination directory
-            Directory.CreateDirectory(destinationDir);
-
-            // Get the files in the source directory and copy to the destination directory
-            foreach (FileInfo file in dir.GetFiles())
+            try
             {
-                string targetFilePath = Path.Combine(destinationDir, file.Name);
-                file.CopyTo(targetFilePath);
-            }
+                // Get information about the source directory
+                var dir = new DirectoryInfo(sourceDir);
 
-            // If recursive and copying subdirectories, recursively call this method
-            if (recursive)
-            {
-                foreach (DirectoryInfo subDir in dirs)
+                // Check if the source directory exists
+                if (!dir.Exists)
+                    throw new DirectoryNotFoundException($"Source directory not found: {dir.FullName}");
+
+                // Cache directories before we start copying
+                DirectoryInfo[] dirs = dir.GetDirectories();
+
+                // Create the destination directory
+                Directory.CreateDirectory(destinationDir);
+
+                // Get the files in the source directory and copy to the destination directory
+                foreach (FileInfo file in dir.GetFiles())
                 {
-                    string newDestinationDir = Path.Combine(destinationDir, subDir.Name);
-                    CopyDirectory(subDir.FullName, newDestinationDir, true);
+                    string targetFilePath = Path.Combine(destinationDir, file.Name);
+                    file.CopyTo(targetFilePath);
                 }
+
+                // If recursive and copying subdirectories, recursively call this method
+                if (recursive)
+                {
+                    foreach (DirectoryInfo subDir in dirs)
+                    {
+                        string newDestinationDir = Path.Combine(destinationDir, subDir.Name);
+                        CopyDirectory(subDir.FullName, newDestinationDir, true);
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine(ex.Message);
             }
         }
         

--- a/Program.cs
+++ b/Program.cs
@@ -159,7 +159,7 @@ namespace NineChronicles.Snapshot
                 _stateStore.CopyStates(ImmutableHashSet<HashDigest<SHA256>>.Empty
                     .Add((HashDigest<SHA256>)snapshotTipStateRootHash), newStateStore);
                 var end = DateTimeOffset.Now;
-                Console.WriteLine("CopyStates Done. Time Taken: {0}", (end - start).Minutes);
+                Console.WriteLine("CopyStates Done. Time Taken(min): {0}", (end - start).Minutes);
 
                 var latestBlockEpoch = (int) (tip.Timestamp.ToUnixTimeSeconds() / blockEpochUnitSeconds);
                 var latestBlockWithTx = GetLatestBlockWithTransaction<DummyAction>(tip, _store);
@@ -168,13 +168,14 @@ namespace NineChronicles.Snapshot
 
                 _store.Dispose();
                 _stateStore.Dispose();
+                newStateKeyValueStore.Dispose();
 
                 Console.WriteLine("Move States Start.");
                 start = DateTimeOffset.Now;
                 Directory.Delete(statesPath, recursive: true);
                 Directory.Move(newStatesPath, statesPath);
                 end = DateTimeOffset.Now;
-                Console.WriteLine("Move States Done. Time Taken: {0}", (end - start).Minutes);
+                Console.WriteLine("Move States Done. Time Taken(min): {0}", (end - start).Minutes);
 
                 var partitionBaseFilename = GetPartitionBaseFileName(
                     currentMetadataBlockEpoch,
@@ -203,19 +204,19 @@ namespace NineChronicles.Snapshot
                     fullSnapshotPath,
                     storePath);
                 end = DateTimeOffset.Now;
-                Console.WriteLine("Clean Store Done. Time Taken: {0}", (end - start).Minutes);
+                Console.WriteLine("Clean Store Done. Time Taken(min): {0}", (end - start).Minutes);
                 if (snapshotType == SnapshotType.Partition || snapshotType == SnapshotType.All)
                 {
                     Console.WriteLine("Clone Partition Directory Start.");
                     start = DateTimeOffset.Now;
                     CopyDirectory(storePath, partitionDirectory, true);
                     end = DateTimeOffset.Now;
-                    Console.WriteLine("Clone Partition Directory Done. Time Taken: {0}", (end - start).Minutes);
+                    Console.WriteLine("Clone Partition Directory Done. Time Taken(min): {0}", (end - start).Minutes);
                     Console.WriteLine("Clone State Directory Start.");
                     start = DateTimeOffset.Now;
                     CopyDirectory(storePath, stateDirectory, true);
                     end = DateTimeOffset.Now;
-                    Console.WriteLine("Clone Directory Done. Time Taken: {0}", (end - start).Minutes);
+                    Console.WriteLine("Clone Directory Done. Time Taken(min): {0}", (end - start).Minutes);
                     var blockPath = Path.Combine(partitionDirectory, "block");
                     var txPath = Path.Combine(partitionDirectory, "tx");
 
@@ -238,7 +239,7 @@ namespace NineChronicles.Snapshot
                     CleanPartitionStore(partitionDirectory);
                     CleanStateStore(stateDirectory);
                     end = DateTimeOffset.Now;
-                    Console.WriteLine("Clean Stores Done. Time Taken: {0}", (end - start).Minutes);
+                    Console.WriteLine("Clean Stores Done. Time Taken(min): {0}", (end - start).Minutes);
                 }
                 
                 if (snapshotType == SnapshotType.Full || snapshotType == SnapshotType.All)
@@ -252,12 +253,12 @@ namespace NineChronicles.Snapshot
                     start = DateTimeOffset.Now;
                     ZipFile.CreateFromDirectory(partitionDirectory, partitionSnapshotPath);
                     end = DateTimeOffset.Now;
-                    Console.WriteLine("Create Partition ZipFile Done. Time Taken: {0}", (end - start).Minutes);
+                    Console.WriteLine("Create Partition ZipFile Done. Time Taken(min): {0}", (end - start).Minutes);
                     Console.WriteLine("Create State ZipFile Start.");
                     start = DateTimeOffset.Now;
                     ZipFile.CreateFromDirectory(stateDirectory, stateSnapshotPath);
                     end = DateTimeOffset.Now;
-                    Console.WriteLine("Create State Zipfile Done. Time Taken: {0}", (end - start).Minutes);
+                    Console.WriteLine("Create State Zipfile Done. Time Taken(min): {0}", (end - start).Minutes);
                     if (snapshotTipDigest is null)
                     {
                         throw new CommandExitedException("Tip does not exist.", -1);

--- a/Program.cs
+++ b/Program.cs
@@ -194,6 +194,8 @@ namespace NineChronicles.Snapshot
                 stateDirectory);
             if (snapshotType == SnapshotType.Partition || snapshotType == SnapshotType.All)
             {
+                CloneDirectory(storePath, partitionDirectory);
+                CloneDirectory(storePath, stateDirectory);
                 var blockPath = Path.Combine(partitionDirectory, "block");
                 var txPath = Path.Combine(partitionDirectory, "tx");
 


### PR DESCRIPTION
This PR fixes the eviction that occurs when `Copying` directories to create snapshot files and adds temporary logging for debugging purposes. 

ToDo: Optimize copying directories