### PR TITLE
Bump .NET 6

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,6 +10,6 @@ jobs:
         uses: actions/checkout@v1
       - uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: '3.1.x'
+          dotnet-version: '6.0.x'
       - name: build
         run: dotnet build NineChronicles.Snapshot.csproj

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/core/sdk:3.1 AS build-env
+FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build-env
 WORKDIR /app
 ARG COMMIT
 
@@ -15,7 +15,7 @@ RUN dotnet publish NineChronicles.Snapshot.csproj \
     --version-suffix $COMMIT
 
 # Build runtime image
-FROM mcr.microsoft.com/dotnet/core/aspnet:3.1
+FROM mcr.microsoft.com/dotnet/aspnet:6.0
 WORKDIR /app
 RUN apt-get update && apt-get install -y libc6-dev
 COPY --from=build-env /app/out .

--- a/NineChronicles.Snapshot.csproj
+++ b/NineChronicles.Snapshot.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <LangVersion>8</LangVersion>
   </PropertyGroup>
 


### PR DESCRIPTION
The .NET 3.1 support will be ended at Dec 13, 2022. This pull request bumps .NET version to 6.