### PR TITLE
Check arguments in download-snapshot.ps1

### DIFF
--- a/download-snapshot.ps1
+++ b/download-snapshot.ps1
@@ -1,3 +1,8 @@
+if ($args.Length -lt 2) {
+	Write-Error "'baseUrl' and 'file_path' arguments are required.";
+	exit -1;
+}
+
 $baseUrl = $args[0]
 $file_path = $args[1]
 $latest = "$($baseUrl)latest.json"


### PR DESCRIPTION
Because there is no check for arguments before downloading snapshots, users cannot know their misuse before errors are raised.

This pull request checks it.